### PR TITLE
Set display mode with test

### DIFF
--- a/BroDisplaySetup.csproj
+++ b/BroDisplaySetup.csproj
@@ -5,9 +5,9 @@
     <TargetFramework>net7.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-	<Version>0.9.0-beta</Version>
-	<AssemblyVersion>0.9.0</AssemblyVersion>
-	<FileVersion>0.9.0</FileVersion>
+	<Version>0.9.1-beta</Version>
+	<AssemblyVersion>0.9.1</AssemblyVersion>
+	<FileVersion>0.9.1</FileVersion>
 	<Authors>Joe Siponen</Authors>
 	<Copyright>© 2023 Joe Siponen</Copyright>
 	<Company>Kristinehamns kommun</Company>


### PR DESCRIPTION
Try to fix bug with display modes being "remembered" when disconnecting from a widescreen display (DELL) to two or more displays setup while the computer is on.